### PR TITLE
syncing dbt cloud and vs code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 dbt_packages/
 logs/
+PROJECTS/.venv/

--- a/src/notebooks/etl.ipynb
+++ b/src/notebooks/etl.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1b050f9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[FileInfo(path='/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/jaffle_shop_customers.csv', name='jaffle_shop_customers.csv', size=1304, modificationTime=1755050873000),\n",
+       " FileInfo(path='/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/jaffle_shop_orders.csv', name='jaffle_shop_orders.csv', size=2625, modificationTime=1755050873000),\n",
+       " FileInfo(path='/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/stripe_payments.csv', name='stripe_payments.csv', size=4997, modificationTime=1755050873000)]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dbutils.fs.ls(\"/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6ef67861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shop_customers = spark.read.option(\"header\", True).option(\"sep\", \",\").csv(\"/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/jaffle_shop_customers.csv\")\n",
+    "shop_orders = spark.read.option(\"header\", True).option(\"sep\", \",\").csv(\"/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/jaffle_shop_orders.csv\")\n",
+    "stripe_payments = spark.read.option(\"header\", True).option(\"sep\", \",\").csv(\"/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw/stripe_payments.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "89af055f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shop_customers.write \\\n",
+    "    .format(\"delta\") \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .saveAsTable(\"one_lake_dev.bronze.tb_eco_jaffle_shop_customers\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "b3847271",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shop_orders.write \\\n",
+    "    .format(\"delta\") \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .saveAsTable(\"one_lake_dev.bronze.tb_eco_jaffle_shop_orders\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "7db2305b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stripe_payments.write \\\n",
+    "    .format(\"delta\") \\\n",
+    "    .mode(\"overwrite\") \\\n",
+    "    .saveAsTable(\"one_lake_dev.bronze.tb_eco_stripe_payments\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a new ETL notebook, `src/notebooks/etl.ipynb`, to the project. The notebook demonstrates how to read raw CSV files from a data lake using Spark, and then write them as Delta tables in the bronze layer. The main changes are focused on loading data and persisting it in a standardized format for downstream processing.

Data ingestion and processing:

* Reads three raw CSV files (`jaffle_shop_customers.csv`, `jaffle_shop_orders.csv`, `stripe_payments.csv`) from the `/Volumes/one_lake_dev/bronze/landzone/dbt-project/raw` directory using Spark.
* Writes each dataset to the bronze layer as Delta tables: `tb_eco_jaffle_shop_customers`, `tb_eco_jaffle_shop_orders`, and `tb_eco_stripe_payments` in the `one_lake_dev.bronze` schema, overwriting any existing tables.